### PR TITLE
Drop support for Python 3.8. Add support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install package
       run: |
         pip install -U .

--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ percent formatting but treat either the format method or f-strings as errors
 Installation and usage
 ----------------------
 
-Python 3.8 or later is required.
+Python 3.9 or later is required.
 
 We recommend installing the plugin using pip, which handles the dependencies::
 
@@ -176,7 +176,8 @@ Version History
 ======= ========== ===========================================================
 Version Released   Changes
 ------- ---------- -----------------------------------------------------------
-v1.0.1  *Pending*  - Requires at least Python 3.8 (no code changes).
+v1.0.1  *Pending*  - Requires at least Python 3.9.
+                   - Add support for Python 3.14.
 v1.0.0  2023-11-01 - Calling this version 1.0.0 as has been stable for years.
                    - Updates to documentation and PyPI metadata.
 v0.0.4  2022-11-01 - Requires at least Python 3.7.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   'Programming Language :: Python :: 3',
   'Programming Language :: Python :: 3 :: Only'
 ]
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = ['flake8>=3']
 dynamic = ['version']
 [project.entry-points]


### PR DESCRIPTION
The deprecated `ast.Num` and `ast.Str` classes are going to be removed:

https://docs.python.org/3.14/whatsnew/3.14.html#id10